### PR TITLE
Fix Mermaid ER diagram syntax errors

### DIFF
--- a/Analisis/Diagramas/DiagramaER.md
+++ b/Analisis/Diagramas/DiagramaER.md
@@ -67,7 +67,7 @@ erDiagram
 
     PAGO {
         int idPago PK
-        int idSolicitud FK  // nullable: pagos pueden existir sin solicitud
+        int idSolicitud FK
     }
 
     CAPACITADOR {
@@ -85,7 +85,5 @@ erDiagram
     DOCUMENTO_REQUERIDO ||--o{ DOCUMENTO : define
     SOLICITUD ||--o{ DOCUMENTO : incluye
     SOLICITUD ||--o{ PAGO : genera
-    # Nota: la relación entre pago y usuario/evento es indirecta vía SOLICITUD.
-    # No se modelan FKs directas de usuario/evento en PAGO para evitar redundancia.
     USUARIO ||--|| CAPACITADOR : es
 ```


### PR DESCRIPTION
## Changes
- Removed invalid comments (`//` and `#`) from Mermaid ER diagram
- Cleaned up syntax to allow proper rendering on GitHub

The diagram was failing to render due to unsupported comment syntax in Mermaid. This fix removes those comments while preserving the diagram structure.